### PR TITLE
same zoom speed as our previous polymaps version

### DIFF
--- a/src/Wheel.js
+++ b/src/Wheel.js
@@ -40,7 +40,7 @@ po.wheel = function() {
         } catch (error) {
           // Derp! Hope for the best?
         }
-        delta *= .005;
+        delta *= .001;
       }
 
       /* If smooth zooming is disabled, batch events into unit steps. */


### PR DESCRIPTION
This slows down mouse-wheel scrolling by 5x.

I wonder if we're messing up the safari experience, though.
There's a comment in `Wheel.js`:

``` js
  // mousewheel events are totally broken!
  // https://bugs.webkit.org/show_bug.cgi?id=40441
  // not only that, but Chrome and Safari differ in re. to acceleration!
```

(btw the above bug relates to the speed of mousewheel deltas and is marked as resolved)

Can someone with a mac make a recommendation here?
