### PR TITLE
make the fetch function aware of the tile coordinates

### DIFF
--- a/src/GeoJson.js
+++ b/src/GeoJson.js
@@ -82,7 +82,7 @@ ms.geoJson = function(fetch) {
       var updated = [];
 
       /* Fetch the next batch of features, if so directed. */
-      if (data.next) tile.request = fetch(data.next.href, update);
+      if (data.next) tile.request = doFetch(data.next.href, update, tile);
 
       if (geoJson.tile() && tileBackground) {
         var tileSize = geoJson.map().tileSize();
@@ -100,10 +100,15 @@ ms.geoJson = function(fetch) {
     }
 
     if (url != null) {
-      tile.request = fetch(typeof url == "function" ? url(tile) : url, update);
+      tile.request = doFetch(typeof url == "function" ? url(tile) : url, update, tile);
     } else {
       update({type: "FeatureCollection", features: features || []});
     }
+  }
+
+  function doFetch(url, update, tile) {
+    if (typeof fetch.setTile == "function") fetch.setTile(tile);
+    fetch(url, update);
   }
 
   function copyObject(source) {


### PR DESCRIPTION
It can be useful for transcoders (AKA the "fetch" function) to be aware of the tile's coordinates. Though they are generally available via the url, this is not standardized and is annoying to parse. 

The current use-case is binning.
Binning involves quantizing a tile, which (in general) requires knowledge of its bounds. Servers may occassionall provide responses with enough information (i.e. via `topojson.q`), but in general this cannot be assumed.

The implementation uses the `setTile()` function of the fetch function if it is available (my limited understanding of javascript is that concurrency is not an issue). 

*Proposed documentation:*

If the `fetch` function provides a `setTile` method, it will be invoked with the tile prior to invoking the fetch function. The value passed to `setTile` should be assumed to be valid only during the subsequent execution of the `fetch`. That is, the supplied tile should not accessed at a later point in time, most notably in callback functions. The supplied tile should not be modified.

I see-sawed between using a `setTile` method just adding a parameter. The benefit of the function is that layers extending `GeoJson` need not worry about correctly passing along arguments. The expense is that it's more complicated to use and easier to misuse. Thoughts?